### PR TITLE
Ensure response body is a binary in Oaskit.Test.valid_response

### DIFF
--- a/lib/oaskit/test.ex
+++ b/lib/oaskit/test.ex
@@ -123,6 +123,8 @@ defmodule Oaskit.Test do
   end
 
   defp json_decode!(data) do
+    data = IO.iodata_to_binary(data)
+
     case data do
       "" -> ""
       payload -> JSV.Codec.decode!(payload)


### PR DESCRIPTION
Since `conn.resp_body` type is [iodata](https://hexdocs.pm/plug/Plug.Conn.html#t:body/0), it can be an `iolist` while `JSV.Codec.decode!` expect a binary today